### PR TITLE
Video ad still runs in background

### DIFF
--- a/motdgdadverts/lua/autorun/client/cl_init.lua
+++ b/motdgdadverts/lua/autorun/client/cl_init.lua
@@ -35,7 +35,7 @@ end
 function enableMotdGDClose()
         motdgdbutton:SetDisabled( false )
         motdgdbutton:SetText( "Close" )
-        motdgdbutton.DoClick = function() motdgdwindow:SetVisible( false ) end
+        motdgdbutton.DoClick = function() motdgdwindow:SetVisible( false ) motdgdwindow:Remove() end
 end
 
 function motdGDCountDown()


### PR DESCRIPTION
After pressing the 'Close' button a video still runs in background so that the sound of this video lasts and can be heard. This can be fixed by removing the whole HTML Panel so that the window is not only visible anymore, it is completely removed in addition.
